### PR TITLE
Hide command patch

### DIFF
--- a/src/main/java/me/gotitim/clientcrasher/command/AlwaysCrashCommand.java
+++ b/src/main/java/me/gotitim/clientcrasher/command/AlwaysCrashCommand.java
@@ -11,10 +11,6 @@ import java.util.List;
 public class AlwaysCrashCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if(!sender.isOp()) {
-            sender.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact server administrators if you believe that this is in error.");
-            return true;
-        }
         if(args.length == 0) return false;
         List<String> alwaysCrash = ClientCrasher.getInstance().getConfig().getStringList("always-crash");
         if(alwaysCrash.contains(args[0])) {

--- a/src/main/java/me/gotitim/clientcrasher/command/CrashCommand.java
+++ b/src/main/java/me/gotitim/clientcrasher/command/CrashCommand.java
@@ -11,10 +11,6 @@ import org.bukkit.entity.Player;
 public class CrashCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if(!sender.isOp()) {
-            sender.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact server administrators if you believe that this is in error.");
-            return true;
-        }
         if(args.length == 0) return false;
         Player player = Bukkit.getPlayer(args[0]);
         if(player == null) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,11 +3,25 @@ version: '${project.version}'
 main: me.gotitim.clientcrasher.ClientCrasher
 api-version: 1.15
 description: Gud punishment for cheaters!
+permissions :
+  clientcrasher.command.*:
+    description: Permission to use all ClientCrasher commands
+    default: op
+    children:
+      clientcrasher.command.crash: true
+  clientcrasher.command.crash:
+    description: Permission to use the normal crash command.
+    default: op
+  clientcrasher.command.alwayscrash:
+    description: Permission to use the alwayscrash command.
+    default: op
 commands:
   crash:
+    permission: clientcrasher.command.crash
     description: Crash player's game
     usage: "§cUsage: /crash <player>"
   alwayscrash:
+    permission: clientcrasher.command.alwayscrash
     description: Add/remove entry from always crashing list
     usage: "§cUsage: /alwayscrash <nick/uuid>"
     aliases:


### PR DESCRIPTION
Currently, the command and plugin namespace appears for permission-less players (as pointed out by #5), which is not ideal in the case that the user is trying to be sneaky (discourage unwanted players, etc.).

I've tweaked the `plugin.yml` so that the commands are not tab completed to players without the newly added permissions, `clientcrasher.command.*`, `clientcrasher.command.crash`, and `clientcrasher.command.alwayscrash`. 

I've also removed the no permission message in the individual command files.

(Also attached is testing, in case my glamorous avatar is insufficient in convincing you that it works)
<img width="607" alt="Screenshot 2024-05-07 at 9 26 26 PM" src="https://github.com/goteusz-maszyk/ClientCrasher-Spigot/assets/69229995/ccc6595f-e5e3-45b1-b587-115edc34db1f">